### PR TITLE
hotfix: header layout 수정

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,9 +15,9 @@ function Header() {
   };
 
   return (
-    <header className="border-foundation-gray-5 sticky top-0 z-50 w-full border-b bg-white">
-      <nav className="flex h-20 items-center gap-[500px]">
-        <div className="to-foundation-blue-9 font-pretendard bg-linear-to-r from-[#42C2FF] bg-clip-text px-2.5 py-5 text-3xl font-extrabold text-transparent">
+    <header className="border-foundation-gray-5 z-50o sticky top-0 w-full border-b bg-white">
+      <nav className="mx-auto flex h-20 max-w-360 items-center gap-125">
+        <div className="to-foundation-blue-9 font-pretendard bg-linear-to-r from-[#42C2FF] bg-clip-text px-2.5 py-5 pl-15 text-3xl font-extrabold text-transparent">
           SIMVEX
         </div>
         <div className="flex gap-10">


### PR DESCRIPTION
## 🔑 Key Changes

- header 컴포넌트 레이아웃 변경
  - padding left 60px 추가
  - header 최대 크기 1440px로 수정
  - header 가운데 오게 수정

### 📸 Screenshots (Optional)

-

## 🙋‍♂️ To Reviewers

-

## 🔗 Issues

-
